### PR TITLE
Add Angular frontend skeleton

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json.schemastore.org/angular-cli",
+  "version": 1,
+  "projects": {
+    "seiscomp-frontend": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/seiscomp-frontend",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [{
+                "replace": "src/environments/environment.ts",
+                "with": "src/environments/environment.prod.ts"
+              }],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "seiscomp-frontend:build"
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "seiscomp-frontend"
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "seiscomp-frontend",
+  "version": "0.0.1",
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^17.1.0",
+    "@angular/common": "^17.1.0",
+    "@angular/compiler": "^17.1.0",
+    "@angular/core": "^17.1.0",
+    "@angular/forms": "^17.1.0",
+    "@angular/platform-browser": "^17.1.0",
+    "@angular/platform-browser-dynamic": "^17.1.0",
+    "@angular/router": "^17.1.0",
+    "leaflet": "^1.9.4",
+    "rxjs": "^7.8.1",
+    "zone.js": "^0.14.1"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.1.0",
+    "typescript": "~5.3.3"
+  }
+}

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -1,0 +1,4 @@
+#map {
+  width: 100%;
+  height: 500px;
+}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,0 +1,7 @@
+<h1>Últimos Sismos</h1>
+<div id="map" style="height:500px"></div>
+<ul>
+  <li *ngFor="let q of earthquakes">
+    {{ q.hora }} - Magnitud {{ q.magnitud }} ({{ q.latitud }}, {{ q.longitud }})
+  </li>
+</ul>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,54 @@
+import { Component, AfterViewInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import * as L from 'leaflet';
+
+interface Earthquake {
+  publicID: string;
+  hora: string;
+  magnitud: number;
+  latitud: number;
+  longitud: number;
+  profundidad: number;
+}
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+export class AppComponent implements AfterViewInit {
+  earthquakes: Earthquake[] = [];
+  map!: L.Map;
+
+  constructor(private http: HttpClient) {}
+
+  ngAfterViewInit() {
+    this.map = L.map('map').setView([0, 0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© OpenStreetMap contributors'
+    }).addTo(this.map);
+    this.loadData();
+  }
+
+  loadData() {
+    this.http.get<Earthquake[]>('/api/earthquakes').subscribe(data => {
+      this.earthquakes = data;
+      this.drawMarkers();
+    });
+  }
+
+  drawMarkers() {
+    for (const q of this.earthquakes) {
+      L.circle([q.latitud, q.longitud], {
+        radius: q.magnitud * 2000,
+        color: 'red',
+        fillOpacity: 0.5
+      }).addTo(this.map).bindPopup(`Mag: ${q.magnitud} - ${q.hora}`);
+    }
+    if (this.earthquakes.length) {
+      const bounds = this.earthquakes.map(q => [q.latitud, q.longitud]) as [number, number][];
+      this.map.fitBounds(bounds);
+    }
+  }
+}

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: true
+};

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: false
+};

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Seiscomp Frontend</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,7 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideHttpClient } from '@angular/common/http';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, {
+  providers: [provideHttpClient()]
+}).catch(err => console.error(err));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,6 @@
+/* Global styles */
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 0;
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "es2020",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2020", "dom"]
+  }
+}

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\PgaRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ApiController extends AbstractController
+{
+    private PgaRepository $repository;
+
+    public function __construct(PgaRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    #[Route('/api/earthquakes', name: 'api_earthquakes', methods: ['GET'])]
+    public function earthquakes(): JsonResponse
+    {
+        $data = $this->repository->findSismo();
+        return $this->json($data);
+    }
+}


### PR DESCRIPTION
## Summary
- add API controller endpoint `/api/earthquakes`
- scaffold Angular project in `frontend`
- implement map and list using Leaflet in Angular component

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433ea63f6c8331af3badc5c3f00103